### PR TITLE
docs: update README with filter expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,16 @@ Event.query(A.my_other_field == 12345, index="my_other_field-index")
 # note: Must provide a condition expression rather than just the value
 Event.query(123545, index="my_other_field-index")  # errors!
 
+# query an index with an optional filter expression
+filter_expression = None
+if filter_value:
+    filter_expression = A('filter_field').eq(filter_value)
+Event.query(
+    A.my_other_field == 12345, 
+    index="my_other_field-index",
+    filter_expression=filter_expression
+)
+
 # consistent read
 Event.query("some_event_id", consistent_read=True)
 ```


### PR DESCRIPTION
## Overview
Tweak to the root README to include documentation around filtering index queries when optional filter expressions are present. 

## Motivation
The desire to add this comes from having to dig into the code to understand the mechanics of `Dyntastic.query()` to figure  out how to dynamically pass a `filter_expression` into the query function -- which I imagine is a common use case when processing a FastAPI request with optional filter query params.

Hope this helps; if you don't feel this is appropriately useful or clutters the README, feel free to disregard - no feelings hurt on my end. Thanks for this library - it's been supremely useful to us 👍 🚀 🙏 