### PR TITLE
Add support for scan_index_forward option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0 2023-04-16
+
+- Add support for `scan_index_forward` for specifying ascending (True) or descending (False) traversal of the index.
+
 ## 0.9.0 2023-04-15
 
 - Add support for `__table_host__` for local testing

--- a/README.md
+++ b/README.md
@@ -148,13 +148,17 @@ filter_expression = None
 if filter_value:
     filter_expression = A('filter_field').eq(filter_value)
 Event.query(
-    A.my_other_field == 12345, 
+    A.my_other_field == 12345,
     index="my_other_field-index",
     filter_expression=filter_expression
 )
 
 # consistent read
 Event.query("some_event_id", consistent_read=True)
+
+# specifies the order for index traversal, the default is ascending order
+# returns the results in the order in which they are stored by sort key value
+Event.query("some_event_id", range_key_condition=A.version.begins_with("2023"), scan_index_forward=False)
 ```
 
 If you need to manually handle pagination, use `query_page`:

--- a/dyntastic/main.py
+++ b/dyntastic/main.py
@@ -25,7 +25,6 @@ _T = TypeVar("_T", bound="Dyntastic")
 
 
 class _TableMetadata:
-    # TODO: add __table_host__?
     __table_name__: Union[str, Callable[[], str]]
     __table_region__: Optional[str] = None
     __table_host__: Optional[str] = None
@@ -157,6 +156,7 @@ class Dyntastic(_TableMetadata, BaseModel):
         index: Optional[str] = None,
         per_page: Optional[int] = None,
         last_evaluated_key: Optional[dict] = None,
+        scan_index_forward: bool = True,
     ) -> Generator[_T, None, None]:
         while True:
             result = cls.query_page(
@@ -167,6 +167,7 @@ class Dyntastic(_TableMetadata, BaseModel):
                 index=index,
                 per_page=per_page,
                 last_evaluated_key=last_evaluated_key,
+                scan_index_forward=scan_index_forward,
             )
 
             last_evaluated_key = result.last_evaluated_key
@@ -186,6 +187,7 @@ class Dyntastic(_TableMetadata, BaseModel):
         index: Optional[str] = None,
         per_page: Optional[int] = None,
         last_evaluated_key: Optional[dict] = None,
+        scan_index_forward: bool = True,
     ) -> ResultPage[_T]:
         if index and consistent_read:
             raise ValueError("Cannot perform a consistent read against a secondary index")
@@ -208,6 +210,7 @@ class Dyntastic(_TableMetadata, BaseModel):
             ExclusiveStartKey=last_evaluated_key,
             KeyConditionExpression=key_condition,
             FilterExpression=filter_condition,
+            ScanIndexForward=scan_index_forward,
         )
 
         raw_items = response.get("Items")

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ DEV_REQUIRES = [
 
 setup(
     name="dyntastic",
-    version="0.9.0",
+    version="0.10.0",
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,4 +1,3 @@
-import operator
 from datetime import datetime
 
 import botocore
@@ -149,9 +148,12 @@ def test_query_scan_index_forward(populated_range_model, scan_index_forward):
         )
     )
 
-    cmp = operator.gt
-    if scan_index_forward is True:
-        cmp = operator.lt
-
     assert len(results) == 2
-    assert cmp(results[0].timestamp, results[1].timestamp)
+
+    timestamp1 = results[0].timestamp
+    timestamp2 = results[1].timestamp
+
+    if scan_index_forward:
+        assert timestamp1 < timestamp2
+    else:
+        assert timestamp2 < timestamp1

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,3 +1,4 @@
+import operator
 from datetime import datetime
 
 import botocore
@@ -138,3 +139,19 @@ def test_query_by_page(populated_range_model):
     assert len(second_page.items) == 1
     assert second_page.last_evaluated_key is None
     assert not second_page.has_more
+
+
+@pytest.mark.parametrize("scan_index_forward", [True, False])
+def test_query_scan_index_forward(populated_range_model, scan_index_forward):
+    results = list(
+        populated_range_model.query(
+            "id1", range_key_condition=A.timestamp.begins_with("2022"), scan_index_forward=scan_index_forward
+        )
+    )
+
+    cmp = operator.gt
+    if scan_index_forward is True:
+        cmp = operator.lt
+
+    assert len(results) == 2
+    assert cmp(results[0].timestamp, results[1].timestamp)


### PR DESCRIPTION
Based on the Dynamodb [Query docs](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-ScanIndexForward) I have a proposal to implement `scan_index_forward` option which allows setting the sorting direction for supported columns.