### PR TITLE
Transaction configurable commit limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,36 @@ with MyModel.batch_writer(batch_size=2):
 # The final operation is performed here now that the `with` context has exited
 ```
 
+
+### Transactions
+
+Dyntastic supports DynamoDB transactions. Transactions are performed using the
+`transaction` context manager and can be used to perform operations across one or multiple
+tables that reside in the same region.
+
+```python
+from dyntastic import transaction
+
+with transaction():
+    item1 = SomeTable(...)
+    item2 = AnotherTable.get(...)
+    item1.save()
+    item2.update(A.something.set("..."))
+```
+
+Note that DynamoDB limits the number of items that can be written in a single
+transaction to 100 items or 4MB, whichever comes first. Dyntastic can automatically
+flush the transaction in chunks of 100 (or fewer if desired) by passing `auto_commit=True`.
+
+For example, to commit every 50 items:
+```python
+with transaction(auto_commit=True, commit_every=50):
+    item1 = SomeTable(...)
+    item2 = AnotherTable.get(...)
+    item1.save()
+    item2.update(A.something.set("..."))
+```
+
 ### Create a DynamoDB Table
 
 This functionality is currently meant only for use in unit tests as it does not

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ DEV_REQUIRES = [
     "flake8<5; python_version == '3.7'",
     "flake8-bugbear",
     "isort",
-    "moto",
+    "moto==4.2.2",
     "mypy",
     "pre-commit",
     "pytest",


### PR DESCRIPTION
As the 100 transaction it is a dynamodb, I decided to keep it as a hard limit and allowed the context manager to be able to accept smaller batches to commit.