### PR TITLE
Allow batch_get for models with alias keys

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 120
-ignore = E203, W503
+extend-ignore = E203, W503

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.1 2024-03-29
+
+- Make Dyntastic.batch_get work with keys that are aliases on the model fields.
+
 ## 0.14.0 2023-12-21
 
 - Add support for `__table_region__` and `__table_host__` to be lazy callables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 
-## 0.14.1 2024-03-29
+## 0.15.0 2024-05-18
 
 - Make Dyntastic.batch_get work with keys that are aliases on the model fields.
+- Improve error messages when validating keys passed to `get`, `safe_get` or `batch_get`
+- Minor fixes to `batch_get` type hints
 
 ## 0.14.0 2023-12-21
 

--- a/dyntastic/attr.py
+++ b/dyntastic/attr.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from decimal import Decimal
-from typing import Optional, Union
+from typing import Any, Optional, Union, overload
 
 from boto3.dynamodb.conditions import Attr as _DynamoAttr
 from boto3.dynamodb.conditions import Key as _DynamoKey
@@ -10,6 +10,14 @@ from pydantic import BaseModel
 from . import pydantic_compat
 
 # serialization helpers
+
+
+@overload
+def serialize(data: dict) -> dict: ...
+
+
+@overload
+def serialize(data: Any) -> Any: ...
 
 
 # Except for sets and Decimal, pydantic_core.as_jsonable_python would work.

--- a/dyntastic/main.py
+++ b/dyntastic/main.py
@@ -109,8 +109,8 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
         method: str,
         hash_key: Any,
         range_key: Any,
-        hash_key_type: type | None = None,
-        range_key_type: type | None = None,
+        hash_key_type: Optional[Type] = None,
+        range_key_type: Optional[Type] = None,
     ) -> dict:
         key = {cls.__hash_key__: hash_key}
         if cls.__range_key__:

--- a/dyntastic/main.py
+++ b/dyntastic/main.py
@@ -104,18 +104,60 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
         return data
 
     @classmethod
-    def get(cls: Type[_T], hash_key, range_key=None, *, consistent_read: bool = False) -> _T:
-        if cls.__range_key__ and range_key is None:
-            raise ValueError(f"Must provide range_key to {cls.__name__}.get()")
-        elif range_key and cls.__range_key__ is None:
-            raise ValueError(f"Did not expect range_key for {cls.__name__}.get(), found '{range_key}'")
-
+    def _serialize_key(
+        cls,
+        method: str,
+        hash_key: Any,
+        range_key: Any,
+        hash_key_type: type | None = None,
+        range_key_type: type | None = None,
+    ) -> dict:
         key = {cls.__hash_key__: hash_key}
         if cls.__range_key__:
             key[cls.__range_key__] = range_key
 
-        serialized_key = attr.serialize(key)
+        if hash_key_type is None:
+            hash_key_type = pydantic_compat.field_type(cls, cls.__hash_key__)
 
+        # hash key checks
+
+        if not isinstance(hash_key, hash_key_type):
+            raise ValueError(
+                f"Expected hash key to be of type {hash_key_type.__name__}, "
+                f"got {type(hash_key).__name__} in {cls.__name__}.{method}()"
+            )
+
+        if cls.__range_key__ is None:
+            if range_key is not None:
+                raise ValueError(
+                    f"Range key `{range_key}` provided to {cls.__name__}.{method}(), "
+                    "but table does not have a range key"
+                )
+            return attr.serialize(key)
+
+        # range key checks
+
+        if range_key_type is None:
+            range_key_type = pydantic_compat.field_type(cls, cls.__range_key__)
+
+        if range_key is None:
+            raise ValueError(f"Range key required but not provided to {cls.__name__}.{method}()")
+
+        # TODO: In order to run the following check, we would need to support
+        #       *deserializing* the range key e.g. from a string to a datetime, just
+        #       for this check, then re-serialize it before sending to DynamoDB
+
+        # if not isinstance(range_key, range_key_type):
+        #     raise ValueError(
+        #         f"Expected range key to be of type {range_key_type.__name__}, "
+        #         f"got {type(range_key).__name__} in {cls.__name__}.{method}()"
+        #     )
+
+        return attr.serialize(key)
+
+    @classmethod
+    def get(cls: Type[_T], hash_key, range_key=None, *, consistent_read: bool = False) -> _T:
+        serialized_key = cls._serialize_key("get", hash_key, range_key)
         response = cls._dynamodb_table().get_item(Key=serialized_key, ConsistentRead=consistent_read)
         data = response.get("Item")
         if data:
@@ -133,28 +175,23 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
     @classmethod
     def batch_get(
         cls: Type[_T],
-        keys: Union[List[str], List[Tuple[str, str]]],
+        keys: Union[List[Any], List[Tuple[Any, Any]]],
         consistent_read: bool = False,
     ) -> List[_T]:
         hash_key_type = pydantic_compat.field_type(cls, cls.__hash_key__)
-
-        if cls.__range_key__ and not all(isinstance(key, (list, tuple)) and len(key) == 2 for key in keys):
-            raise ValueError(f"Must provide (hash_key, range_key) tuples as `keys` to {cls.__name__}.batch_get()")
-
-        if cls.__range_key__ is None and not all(isinstance(key, hash_key_type) for key in keys):
-            raise ValueError(
-                f"Must only provide {hash_key_type.__name__} types as `keys` to {cls.__name__}.batch_get()"
-            )
+        range_key_type = None
+        if cls.__range_key__:
+            range_key_type = pydantic_compat.field_type(cls, cls.__range_key__)
 
         serialized_keys = []
         for key in keys:
-            if cls.__range_key__:
-                key_dict = {cls.__hash_key__: key[0], cls.__range_key__: key[1]}
-            else:
-                assert isinstance(key, hash_key_type)
-                key_dict = {cls.__hash_key__: key}
-
-            serialized_keys.append(attr.serialize(key_dict))
+            if cls.__range_key__ and (not isinstance(key, (list, tuple)) or len(key) != 2):
+                raise ValueError(
+                    f"Must provide (hash_key, range_key) tuples as `keys` to {cls.__name__}.batch_get(), got {key}"
+                )
+            hash_key, range_key = key if cls.__range_key__ else (key, None)
+            serialized_key = cls._serialize_key("batch_get", hash_key, range_key, hash_key_type, range_key_type)
+            serialized_keys.append(serialized_key)
 
         responses = invoke_with_backoff(
             cls._dynamodb_resource().batch_get_item,
@@ -698,6 +735,13 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
 
         if cls.__range_key__ and not _has_alias(cls, cls.__range_key__):
             raise ValueError(f"Dyntastic __range_key__ is not defined as a field: '{cls.__range_key__}'")
+
+        all_aliases = set()
+        for field_name, field in pydantic_compat.model_fields(cls).items():
+            field_identifier = pydantic_compat.alias(field_name, field)
+            if field_identifier in all_aliases:
+                raise ValueError(f"Duplicate alias '{field_identifier}' found in {cls.__name__}")
+            all_aliases.add(field_identifier)
 
 
 def _has_alias(model: Type[BaseModel], name: str) -> bool:

--- a/dyntastic/pydantic_compat.py
+++ b/dyntastic/pydantic_compat.py
@@ -134,7 +134,14 @@ else:
 
 
 def field_type(model: Type[pydantic.BaseModel], field: str) -> Type:
-    return annotation(model_fields(model)[field])
+    model_field = next(
+        (v for k, v in model_fields(model).items() if field in (k, v.alias)),
+        None,
+    )
+    if model_field:
+        return annotation(model_field)
+
+    raise ValueError(f"Field {field} not found in model {model}")
 
 
 __all__ = [

--- a/dyntastic/pydantic_compat.py
+++ b/dyntastic/pydantic_compat.py
@@ -133,15 +133,22 @@ else:
             return v
 
 
-def field_type(model: Type[pydantic.BaseModel], field: str) -> Type:
-    model_field = next(
-        (v for k, v in model_fields(model).items() if field in (k, v.alias)),
-        None,
-    )
-    if model_field:
-        return annotation(model_field)
+def field_type(model: Type[pydantic.BaseModel], field: str) -> type:
+    fields = model_fields(model)
+    model_field = None
 
-    raise ValueError(f"Field {field} is not present in {model}")
+    # Try to match by alias before by name, to be consistent with pydantic
+    for field_info in fields.values():
+        if field_info.alias == field:
+            model_field = field_info
+            break
+    else:
+        model_field = fields.get(field)
+
+    if model_field is None:
+        raise ValueError(f"Field {field} is not present in {model}")
+
+    return annotation(model_field)
 
 
 __all__ = [

--- a/dyntastic/pydantic_compat.py
+++ b/dyntastic/pydantic_compat.py
@@ -141,7 +141,7 @@ def field_type(model: Type[pydantic.BaseModel], field: str) -> Type:
     if model_field:
         return annotation(model_field)
 
-    raise ValueError(f"Field {field} not found in model {model}")
+    raise ValueError(f"Field {field} is not present in {model}")
 
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,8 @@ ignore_missing_imports = true
 omit = [
     "dyntastic/pydantic_compat.py",
 ]
+
+[tool.coverage.report]
+exclude_also = [
+    "@overload",
+]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ DEV_REQUIRES = [
 
 setup(
     name="dyntastic",
-    version="0.14.1",
+    version="0.15.0",
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ DEV_REQUIRES = [
 
 setup(
     name="dyntastic",
-    version="0.14.0",
+    version="0.14.1",
     description=description,
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,6 +173,19 @@ def item_no_my_str_set(request):
     instance._clear_boto3_state()
 
 
+alias_query_data: List[Dict[str, Any]] = [
+    {
+        "id": "id1",
+    },
+    {
+        "id": "id2",
+    },
+    {
+        "id": "id3",
+    },
+]
+
+
 query_data: List[Dict[str, Any]] = [
     {
         "id": "id1",
@@ -222,6 +235,15 @@ range_query_data: List[Dict[str, Any]] = [
         "my_int": 4,
     },
 ]
+
+
+@pytest.fixture
+def populated_alias_model(request):
+    MyAliasObject.create_table("id/alias")
+    for item in alias_query_data:
+        MyAliasObject(**item).save()
+    yield MyAliasObject
+    MyAliasObject._clear_boto3_state()
 
 
 @pytest.fixture

--- a/tests/test_batch_get.py
+++ b/tests/test_batch_get.py
@@ -1,6 +1,14 @@
 import pytest
 
-from .conftest import MyIntObject, MyObject, MyRangeObject, query_data, range_query_data
+from .conftest import (
+    MyAliasObject,
+    MyIntObject,
+    MyObject,
+    MyRangeObject,
+    alias_query_data,
+    query_data,
+    range_query_data,
+)
 
 hash_keys = [item["id"] for item in query_data]
 loaded_hash_data = [MyObject(**item) for item in query_data]
@@ -8,10 +16,18 @@ loaded_hash_data = [MyObject(**item) for item in query_data]
 hash_range_keys = [(item["id"], item["timestamp"]) for item in range_query_data]
 loaded_range_data = [MyRangeObject(**item) for item in range_query_data]
 
+alias_hash_keys = [item["id"] for item in alias_query_data]
+loaded_alias_hash_data = [MyAliasObject(**item) for item in alias_query_data]
+
 
 def test_get_by_hash_key(populated_model):
     assert populated_model.batch_get(hash_keys) == loaded_hash_data
     assert populated_model.batch_get([*hash_keys, "nonexistent"]) == loaded_hash_data
+
+
+def test_get_by_alias_hash_key(populated_alias_model):
+    assert populated_alias_model.batch_get(alias_hash_keys) == loaded_alias_hash_data
+    assert populated_alias_model.batch_get([*alias_hash_keys]) == loaded_alias_hash_data
 
 
 def test_get_by_int_hash_key(populated_int_model):

--- a/tests/test_batch_get.py
+++ b/tests/test_batch_get.py
@@ -41,7 +41,7 @@ def test_get_by_hash_key_and_range_key(populated_range_model):
 
 
 def test_invalid_keys(populated_model):
-    error_message = rf"Must only provide str types as `keys` to {populated_model.__name__}\.batch_get\(\)"
+    error_message = rf"Expected hash key to be of type str, got tuple in {populated_model.__name__}\.batch_get\(\)"
 
     with pytest.raises(ValueError, match=error_message):
         assert populated_model.batch_get([("hash", "range")]) == []
@@ -54,15 +54,18 @@ def test_invalid_keys(populated_model):
 
 
 def test_invalid_int_keys(populated_int_model):
-    error_message = rf"Must only provide int types as `keys` to {populated_int_model.__name__}\.batch_get\(\)"
+    def error_message(input_type) -> str:
+        return (
+            rf"Expected hash key to be of type int, got {input_type} in {populated_int_model.__name__}\.batch_get\(\)"
+        )
 
-    with pytest.raises(ValueError, match=error_message):
+    with pytest.raises(ValueError, match=error_message("str")):
         assert populated_int_model.batch_get([1, "bad"]) == []
 
-    with pytest.raises(ValueError, match=error_message):
+    with pytest.raises(ValueError, match=error_message("str")):
         assert populated_int_model.batch_get([1, "bad", 2]) == []
 
-    with pytest.raises(ValueError, match=error_message):
+    with pytest.raises(ValueError, match=error_message("tuple")):
         assert populated_int_model.batch_get([1, (2, "bad_range")]) == []
 
 

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -24,12 +24,15 @@ def test_get_with_range_key(range_item):
 
 
 def test_range_key_required(range_item):
-    with pytest.raises(ValueError, match="Must provide range_key to MyRangeObject.get\\(\\)"):
+    with pytest.raises(ValueError, match=r"Range key required but not provided to MyRangeObject.get\(\)"):
         MyRangeObject.get(range_item.id)
 
 
 def test_range_key_not_expected(hash_item):
-    with pytest.raises(ValueError, match="Did not expect range_key for MyObject.get\\(\\), found 'my_range_value'"):
+    with pytest.raises(
+        ValueError,
+        match="Range key `my_range_value` provided to MyObject.get\\(\\), but table does not have a range key",
+    ):
         MyObject.get(hash_item.id, "my_range_value")
 
 
@@ -37,7 +40,7 @@ def test_get_nonexistent(hash_item, range_item):
     with pytest.raises(DoesNotExist):
         MyObject.get("nonexistent")
 
-    with pytest.raises(ValueError, match="Must provide range_key to MyRangeObject.get\\(\\)"):
+    with pytest.raises(ValueError, match="Range key required but not provided to MyRangeObject.get\\(\\)"):
         MyRangeObject.get("nonexistent")
 
     with pytest.raises(DoesNotExist):
@@ -46,7 +49,7 @@ def test_get_nonexistent(hash_item, range_item):
     assert MyObject.safe_get("nonexistent") is None
     assert MyRangeObject.safe_get("nonexistent", "nonexistent_range") is None
 
-    with pytest.raises(ValueError, match="Must provide range_key to MyRangeObject.get\\(\\)"):
+    with pytest.raises(ValueError, match=r"Range key required but not provided to MyRangeObject.get\(\)"):
         MyRangeObject.safe_get("nonexistent")
 
 


### PR DESCRIPTION
Hi!

Love the library. I'm making use of aliases for my hash and range key fields. Currently Dyntastic.batch_get doesn't work in this case. This patches that issue.

Cheers.