### PR TITLE
Fix: Transaction not doing double serialization of the condition

### DIFF
--- a/dyntastic/main.py
+++ b/dyntastic/main.py
@@ -605,7 +605,7 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
         filtered_kwargs["TableName"] = cls._resolve_table_name()
 
         if "ConditionExpression" in filtered_kwargs:
-            condition_data = transact.serialize_condition(filtered_kwargs["ConditionExpression"], False)
+            condition_data = transact.serialize_condition(filtered_kwargs["ConditionExpression"])
             filtered_kwargs["ConditionExpression"] = condition_data["ConditionExpression"]
 
             # Merging condition expression and update expression names/values so they are both present.

--- a/dyntastic/main.py
+++ b/dyntastic/main.py
@@ -605,7 +605,7 @@ class Dyntastic(_TableMetadata, pydantic_compat.BaseModel):
         filtered_kwargs["TableName"] = cls._resolve_table_name()
 
         if "ConditionExpression" in filtered_kwargs:
-            condition_data = transact.serialize_condition(filtered_kwargs["ConditionExpression"])
+            condition_data = transact.serialize_condition(filtered_kwargs["ConditionExpression"], False)
             filtered_kwargs["ConditionExpression"] = condition_data["ConditionExpression"]
 
             # Merging condition expression and update expression names/values so they are both present.

--- a/dyntastic/transact.py
+++ b/dyntastic/transact.py
@@ -28,13 +28,13 @@ def serialize_data(item: dict) -> dict:
     return {k: _dynamodb_serializer.serialize(v) for k, v in item.items()}
 
 
-def serialize_condition(condition, do_serialization = True) -> dict:
+def serialize_condition(condition) -> dict:
     expression = _dynamodb_builder.build_expression(condition)
 
     return {
         "ConditionExpression": expression.condition_expression,
         "ExpressionAttributeNames": expression.attribute_name_placeholders,
-        "ExpressionAttributeValues": serialize_data(expression.attribute_value_placeholders) if do_serialization else expression.attribute_value_placeholders,
+        "ExpressionAttributeValues": expression.attribute_value_placeholders,
     }
 
 

--- a/dyntastic/transact.py
+++ b/dyntastic/transact.py
@@ -28,13 +28,13 @@ def serialize_data(item: dict) -> dict:
     return {k: _dynamodb_serializer.serialize(v) for k, v in item.items()}
 
 
-def serialize_condition(condition) -> dict:
+def serialize_condition(condition, do_serialization = True) -> dict:
     expression = _dynamodb_builder.build_expression(condition)
 
     return {
         "ConditionExpression": expression.condition_expression,
         "ExpressionAttributeNames": expression.attribute_name_placeholders,
-        "ExpressionAttributeValues": serialize_data(expression.attribute_value_placeholders),
+        "ExpressionAttributeValues": serialize_data(expression.attribute_value_placeholders) if do_serialization else expression.attribute_value_placeholders,
     }
 
 


### PR DESCRIPTION
While doing several updates using transactions it was noticed that the value of the condition was getting serialized two times. With these fix you can ask for the double serialization or just disable one.