### PR TITLE
add ipv4 serialization

### DIFF
--- a/dyntastic/attr.py
+++ b/dyntastic/attr.py
@@ -198,9 +198,7 @@ class _ActionRemove(_UpdateAction):
         # ensure that subtypes of int which might have a different
         # __str__ method cannot allow injection
         if index is not None and type(index) is not int:
-            raise ValueError(
-                f"Dyntastic remove() update must be given an int, found '{index.__class__.__name__}'"
-            )
+            raise ValueError(f"Dyntastic remove() update must be given an int, found '{index.__class__.__name__}'")
 
         self.path = path
         self.index = index

--- a/dyntastic/attr.py
+++ b/dyntastic/attr.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from decimal import Decimal
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network
 from typing import Any, Optional, Union, overload
 
 from boto3.dynamodb.conditions import Attr as _DynamoAttr
@@ -36,6 +37,8 @@ def serialize(data):
         return set(map(serialize, data))
     elif isinstance(data, (Decimal, str, int, bytes, bool, float, type(None))):
         return data
+    elif isinstance(data, (IPv4Address, IPv4Interface, IPv4Network)):
+        return serialize(str(data))
     else:
         # handle types like datetime
         return pydantic_compat.to_jsonable_python(data)
@@ -195,7 +198,9 @@ class _ActionRemove(_UpdateAction):
         # ensure that subtypes of int which might have a different
         # __str__ method cannot allow injection
         if index is not None and type(index) is not int:
-            raise ValueError(f"Dyntastic remove() update must be given an int, found '{index.__class__.__name__}'")
+            raise ValueError(
+                f"Dyntastic remove() update must be given an int, found '{index.__class__.__name__}'"
+            )
 
         self.path = path
         self.index = index

--- a/dyntastic/attr.py
+++ b/dyntastic/attr.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from decimal import Decimal
-from ipaddress import IPv4Address, IPv4Interface, IPv4Network
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import Any, Optional, Union, overload
 
 from boto3.dynamodb.conditions import Attr as _DynamoAttr
@@ -37,8 +37,8 @@ def serialize(data):
         return set(map(serialize, data))
     elif isinstance(data, (Decimal, str, int, bytes, bool, float, type(None))):
         return data
-    elif isinstance(data, (IPv4Address, IPv4Interface, IPv4Network)):
-        return serialize(str(data))
+    elif isinstance(data, (IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network)):
+        return str(data)
     else:
         # handle types like datetime
         return pydantic_compat.to_jsonable_python(data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,7 @@
 import os
 from datetime import datetime
 from decimal import Decimal
-from ipaddress import (
-    IPv4Address,
-    IPv4Interface,
-    IPv4Network,
-    IPv6Address,
-    IPv6Interface,
-    IPv6Network,
-)
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 from typing import Any, Dict, List, Optional, Set
 from uuid import uuid4
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,13 @@
-from ipaddress import IPv4Address, IPv4Interface, IPv4Network
 import os
 from datetime import datetime
 from decimal import Decimal
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network
 from typing import Any, Dict, List, Optional, Set
 from uuid import uuid4
 
 import pytest
 from moto import mock_dynamodb
-from pydantic import BaseModel, Field,  IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork
+from pydantic import BaseModel, Field, IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork
 
 from dyntastic import Dyntastic, Index
 
@@ -45,7 +45,6 @@ class MyObject(Dyntastic):
     my_ip_address: Optional[IPvAnyAddress] = None
     my_ip_interface: Optional[IPvAnyInterface] = None
     my_ip_network: Optional[IPvAnyNetwork] = None
-
 
 
 class MyObjectWithRequiredField(MyObject):
@@ -98,9 +97,9 @@ def _create_item(DyntasticModel, **kwargs):
         "my_dict": {"a": 1, "b": 2, "c": 3},
         "my_nested_data": [{"a": [{"foo": "bar"}], "b": "test"}, "some_string"],
         "my_nested_model": MyNestedModel(sample_field="hello"),
-        "my_ip_address": IPv4Address('10.66.0.1'),
-        "my_ip_interface": IPv4Interface('10.66.0.1'),
-        "my_ip_network": IPv4Network('10.66.0.1/32')
+        "my_ip_address": IPv4Address("10.66.0.1"),
+        "my_ip_interface": IPv4Interface("10.66.0.1"),
+        "my_ip_network": IPv4Network("10.66.0.1/32"),
     }
     data.update(kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network
 import os
 from datetime import datetime
 from decimal import Decimal
@@ -6,7 +7,7 @@ from uuid import uuid4
 
 import pytest
 from moto import mock_dynamodb
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field,  IPvAnyAddress, IPvAnyInterface, IPvAnyNetwork
 
 from dyntastic import Dyntastic, Index
 
@@ -41,6 +42,10 @@ class MyObject(Dyntastic):
     my_dict: Optional[dict] = None
     my_nested_data: Optional[Any] = None
     my_nested_model: Optional[MyNestedModel] = None
+    my_ip_address: Optional[IPvAnyAddress] = None
+    my_ip_interface: Optional[IPvAnyInterface] = None
+    my_ip_network: Optional[IPvAnyNetwork] = None
+
 
 
 class MyObjectWithRequiredField(MyObject):
@@ -93,6 +98,9 @@ def _create_item(DyntasticModel, **kwargs):
         "my_dict": {"a": 1, "b": 2, "c": 3},
         "my_nested_data": [{"a": [{"foo": "bar"}], "b": "test"}, "some_string"],
         "my_nested_model": MyNestedModel(sample_field="hello"),
+        "my_ip_address": IPv4Address('10.66.0.1'),
+        "my_ip_interface": IPv4Interface('10.66.0.1'),
+        "my_ip_network": IPv4Network('10.66.0.1/32')
     }
     data.update(kwargs)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,14 @@
 import os
 from datetime import datetime
 from decimal import Decimal
-from ipaddress import IPv4Address, IPv4Interface, IPv4Network
+from ipaddress import (
+    IPv4Address,
+    IPv4Interface,
+    IPv4Network,
+    IPv6Address,
+    IPv6Interface,
+    IPv6Network,
+)
 from typing import Any, Dict, List, Optional, Set
 from uuid import uuid4
 
@@ -42,9 +49,12 @@ class MyObject(Dyntastic):
     my_dict: Optional[dict] = None
     my_nested_data: Optional[Any] = None
     my_nested_model: Optional[MyNestedModel] = None
-    my_ip_address: Optional[IPvAnyAddress] = None
-    my_ip_interface: Optional[IPvAnyInterface] = None
-    my_ip_network: Optional[IPvAnyNetwork] = None
+    my_ipv4_address: Optional[IPvAnyAddress] = None
+    my_ipv4_interface: Optional[IPvAnyInterface] = None
+    my_ipv4_network: Optional[IPvAnyNetwork] = None
+    my_ipv6_address: Optional[IPv6Address] = None
+    my_ipv6_interface: Optional[IPv6Interface] = None
+    my_ipv6_network: Optional[IPv6Network] = None
 
 
 class MyObjectWithRequiredField(MyObject):
@@ -97,9 +107,12 @@ def _create_item(DyntasticModel, **kwargs):
         "my_dict": {"a": 1, "b": 2, "c": 3},
         "my_nested_data": [{"a": [{"foo": "bar"}], "b": "test"}, "some_string"],
         "my_nested_model": MyNestedModel(sample_field="hello"),
-        "my_ip_address": IPv4Address("10.66.0.1"),
-        "my_ip_interface": IPv4Interface("10.66.0.1"),
-        "my_ip_network": IPv4Network("10.66.0.1/32"),
+        "my_ipv4_address": IPv4Address("10.66.0.1"),
+        "my_ipv4_interface": IPv4Interface("10.66.0.1"),
+        "my_ipv4_network": IPv4Network("10.66.0.1/32"),
+        "my_ipv6_address": IPv6Address("001:db8::"),
+        "my_ipv6_interface": IPv6Interface("001:db8::"),
+        "my_ipv6_network": IPv6Network("2001:db8::1000/124"),
     }
     data.update(kwargs)
 

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -36,12 +36,12 @@ def test_set_existing_attribute(item):
         "my_dict": {"d": 4, "e": 5},
         "my_nested_data": {"foo": ["bar", "baz", "bat"]},
         "my_nested_model": MyNestedModel(sample_field="updated"),
-        "my_ipv4_address": IPv4Address("10.66.0.1"),
-        "my_ipv4_interface": IPv4Interface("10.66.0.1"),
-        "my_ipv4_network": IPv4Network("10.66.0.1/32"),
-        "my_ipv6_address": IPv6Address("001:db8::"),
-        "my_ipv6_interface": IPv6Interface("001:db8::"),
-        "my_ipv6_network": IPv6Network("2001:db8::1000/124"),
+        "my_ipv4_address": IPv4Address("99.66.0.1"),
+        "my_ipv4_interface": IPv4Interface("99.66.0.1"),
+        "my_ipv4_network": IPv4Network("99.66.0.1/32"),
+        "my_ipv6_address": IPv6Address("991:db8::"),
+        "my_ipv6_interface": IPv6Interface("991:db8::"),
+        "my_ipv6_network": IPv6Network("9901:db8::1000/124"),
     }
 
     updates = [getattr(A, key).set(value) for key, value in new_data.items()]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from decimal import Decimal
-from ipaddress import IPv4Address, IPv4Interface, IPv4Network
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network, IPv6Address, IPv6Interface, IPv6Network
 
 import botocore.exceptions
 import pytest
@@ -36,9 +36,12 @@ def test_set_existing_attribute(item):
         "my_dict": {"d": 4, "e": 5},
         "my_nested_data": {"foo": ["bar", "baz", "bat"]},
         "my_nested_model": MyNestedModel(sample_field="updated"),
-        "my_ip_address": IPv4Address("10.66.0.1"),
-        "my_ip_interface": IPv4Interface("10.66.0.1"),
-        "my_ip_network": IPv4Network("10.66.0.1/32"),
+        "my_ipv4_address": IPv4Address("10.66.0.1"),
+        "my_ipv4_interface": IPv4Interface("10.66.0.1"),
+        "my_ipv4_network": IPv4Network("10.66.0.1/32"),
+        "my_ipv6_address": IPv6Address("001:db8::"),
+        "my_ipv6_interface": IPv6Interface("001:db8::"),
+        "my_ipv6_network": IPv6Network("2001:db8::1000/124"),
     }
 
     updates = [getattr(A, key).set(value) for key, value in new_data.items()]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,7 +1,7 @@
-from ipaddress import IPv4Address, IPv4Interface, IPv4Network
 import re
 from datetime import datetime
 from decimal import Decimal
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network
 
 import botocore.exceptions
 import pytest
@@ -36,9 +36,9 @@ def test_set_existing_attribute(item):
         "my_dict": {"d": 4, "e": 5},
         "my_nested_data": {"foo": ["bar", "baz", "bat"]},
         "my_nested_model": MyNestedModel(sample_field="updated"),
-        "my_ip_address": IPv4Address('10.66.0.1'),
-        "my_ip_interface": IPv4Interface('10.66.0.1'),
-        "my_ip_network": IPv4Network('10.66.0.1/32')
+        "my_ip_address": IPv4Address("10.66.0.1"),
+        "my_ip_interface": IPv4Interface("10.66.0.1"),
+        "my_ip_network": IPv4Network("10.66.0.1/32"),
     }
 
     updates = [getattr(A, key).set(value) for key, value in new_data.items()]

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,3 +1,4 @@
+from ipaddress import IPv4Address, IPv4Interface, IPv4Network
 import re
 from datetime import datetime
 from decimal import Decimal
@@ -35,6 +36,9 @@ def test_set_existing_attribute(item):
         "my_dict": {"d": 4, "e": 5},
         "my_nested_data": {"foo": ["bar", "baz", "bat"]},
         "my_nested_model": MyNestedModel(sample_field="updated"),
+        "my_ip_address": IPv4Address('10.66.0.1'),
+        "my_ip_interface": IPv4Interface('10.66.0.1'),
+        "my_ip_network": IPv4Network('10.66.0.1/32')
     }
 
     updates = [getattr(A, key).set(value) for key, value in new_data.items()]


### PR DESCRIPTION
Small edit to add ipv4 address, interface and networks to the serialize function.

As they are just strings, rerunning the `serialize` function as a string is fine, Pydantic takes care of the deserialization.


Could also expand to ipv6 and other Pydantic utility classes which are just strings under the hood.


Not sure if I got the test code right, advice would be great.