### PR TITLE
feat(table): support billing_mode in create_table()

### DIFF
--- a/tests/test_create_table.py
+++ b/tests/test_create_table.py
@@ -29,3 +29,11 @@ def test_create_table_region():
     assert MyRegionObject._dynamodb_client().meta.region_name == "us-east-2"
     MyRegionObject.create_table()
     assert list(MyRegionObject.scan()) == []
+
+
+def test_create_table_on_demand():
+    MyObject.create_table(wait=True, billing_mode="PAY_PER_REQUEST")
+    assert list(MyObject.scan()) == []
+
+    desc = MyObject._dynamodb_client().describe_table(TableName=MyObject.__table_name__)
+    assert desc["Table"]["BillingModeSummary"]["BillingMode"] == "PAY_PER_REQUEST"


### PR DESCRIPTION
Adds an optional `billing_mode` parameter to `Dyntastic.create_table()`, allowing tables to be created with `PAY_PER_REQUEST` (on-demand) mode instead of the default `PROVISIONED` capacity mode.

Includes a test to verify on-demand table creation and expected billing configuration.

This improves support for dev/test environments where provisioned throughput can lead to throttling or unnecessary cost.